### PR TITLE
Valid W3C URL in fsi_file_path and fsi_file_asset

### DIFF
--- a/Resolver/FSiFilePathResolver.php
+++ b/Resolver/FSiFilePathResolver.php
@@ -110,9 +110,24 @@ class FSiFilePathResolver
         if (isset($prefix)) {
             $prefix = trim($prefix, '/');
 
-            return $prefix . '/' . ltrim($file->getKey(), '/');
+            return $prefix . '/' . ltrim($this->encodeUrl($file->getKey()), '/');
         }
 
-        return $file->getKey();
+        return $this->encodeUrl($file->getKey());
+    }
+
+    /**
+     * @param string $url
+     * @return string
+     */
+    protected function encodeUrl($url)
+    {
+        $encodeUrl = function ($part) {
+            return rawurlencode($part);
+        };
+
+        $encodedUrlParts = array_map($encodeUrl, explode("/", $url));
+
+        return implode("/", $encodedUrlParts);
     }
 }

--- a/Resolver/FSiFilePathResolver.php
+++ b/Resolver/FSiFilePathResolver.php
@@ -122,11 +122,7 @@ class FSiFilePathResolver
      */
     protected function encodeUrl($url)
     {
-        $encodeUrl = function ($part) {
-            return rawurlencode($part);
-        };
-
-        $encodedUrlParts = array_map($encodeUrl, explode("/", $url));
+        $encodedUrlParts = array_map('rawurlencode', explode("/", $url));
 
         return implode("/", $encodedUrlParts);
     }

--- a/Resolver/FSiFilePathResolver.php
+++ b/Resolver/FSiFilePathResolver.php
@@ -58,6 +58,10 @@ class FSiFilePathResolver
         return basename($file->getName());
     }
 
+    /**
+     * @param File $file
+     * @return string
+     */
     public function fileUrl(File $file)
     {
         $filesystem = $file->getFilesystem();
@@ -68,7 +72,7 @@ class FSiFilePathResolver
             ));
         }
 
-        return $filesystem->getBaseUrl() . $file->getKey();
+        return $filesystem->getBaseUrl() . $this->encodeUrl($file->getKey());
     }
 
     /**

--- a/Tests/Form/Type/FSi/FileTypeTest.php
+++ b/Tests/Form/Type/FSi/FileTypeTest.php
@@ -111,11 +111,11 @@ class FileTypeTest extends FormIntegrationTestCase
 
         $file->expects($this->any())
             ->method('getKey')
-            ->will($this->returnValue('Article/file/1/image.jpg'));
+            ->will($this->returnValue('Article/file/1/image name.jpg'));
 
         $file->expects($this->any())
             ->method('getName')
-            ->will($this->returnValue('Article/file/1/image.jpg'));
+            ->will($this->returnValue('Article/file/1/image name.jpg'));
 
         $article = new Article();
         $article->setFile($file);

--- a/Tests/Resources/views/form_with_fsi_file.html
+++ b/Tests/Resources/views/form_with_fsi_file.html
@@ -1,1 +1,1 @@
-<div id="form"><div><label for="form_file">[trans]File[/trans]</label><input type="file" id="form_file" name="form[file]" /><div><a href="/uploaded/Article/file/1/image.jpg" data-for="form_file" target="_blank">image.jpg</a></div></div></div>
+<div id="form"><div><label for="form_file">[trans]File[/trans]</label><input type="file" id="form_file" name="form[file]" /><div><a href="/uploaded/Article/file/1/image%20name.jpg" data-for="form_file" target="_blank">image name.jpg</a></div></div></div>

--- a/spec/FSi/Bundle/DoctrineExtensionsBundle/Resolver/FSiFilePathResolverSpec.php
+++ b/spec/FSi/Bundle/DoctrineExtensionsBundle/Resolver/FSiFilePathResolverSpec.php
@@ -7,10 +7,11 @@
  * file that was distributed with this source code.
  */
 
-namespace spec\FSi\Bundle\DoctrineExtensionsBundle;
+namespace spec\FSi\Bundle\DoctrineExtensionsBundle\Resolver;
 
 use FSi\DoctrineExtensions\Uploadable\File;
 use Gaufrette\Adapter\Local;
+use Gaufrette\Adapter\Cache;
 use Gaufrette\Filesystem;
 use PhpSpec\ObjectBehavior;
 use Twig_Environment;
@@ -24,70 +25,64 @@ class FSiFilePathResolverSpec extends ObjectBehavior
 
     function it_generate_url_for_fsi_file_with_local_adapter(File $file, Filesystem $filesystem, Local $adapter)
     {
-        $file->getKey()->shouldBeCalled()->willReturn('TestFolder/File/file.jpg');
-        $file->getFilesystem()->shouldBeCalled()->willReturn($filesystem);
+        $file->getKey()->willReturn('TestFolder/File/file name.jpg');
+        $file->getFilesystem()->willReturn($filesystem);
         $filesystem->getAdapter()->willReturn($adapter);
 
-        $this->fileAsset($file)->shouldReturn('/TestFolder/File/file.jpg');
-        $this->filePath($file)->shouldReturn('/TestFolder/File/file.jpg');
+        $this->filePath($file)->shouldReturn('/uploaded/TestFolder/File/file%20name.jpg');
     }
 
     function it_generate_url_for_fsi_file_with_cache_adapter(File $file, Filesystem $filesystem, Local $adapter)
     {
-        $file->getKey()->shouldBeCalled()->willReturn('TestFolder/File/file.jpg');
-        $file->getFilesystem()->shouldBeCalled()->willReturn($filesystem);
+        $file->getKey()->willReturn('/TestFolder/File/file&name.jpg');
+        $file->getFilesystem()->willReturn($filesystem);
         $filesystem->getAdapter()->willReturn($adapter);
 
-        $this->fileAsset($file)->shouldReturn('/TestFolder/File/file.jpg');
-        $this->filePath($file)->shouldReturn('/TestFolder/File/file.jpg');
+        $this->filePath($file)->shouldReturn('/uploaded/TestFolder/File/file%26name.jpg');
     }
 
-    function it_generate_url_with_file_path_prefix(File $file, Filesystem $filesystem, Local $adapter)
+    function it_generate_url_with_file_path_prefix(File $file, Filesystem $filesystem, Cache $adapter)
     {
-        $file->getKey()->shouldBeCalled()->willReturn('TestFolder/File/file.jpg');
-        $file->getFilesystem()->shouldBeCalled()->willReturn($filesystem);
+        $file->getKey()->willReturn('/TestFolder/File/file:name.jpg');
+        $file->getFilesystem()->willReturn($filesystem);
         $filesystem->getAdapter()->willReturn($adapter);
 
-        $this->fileAsset($file, 'uploaded')->shouldReturn('/uploaded/TestFolder/File/file.jpg');
-        $this->filePath($file, 'uploaded')->shouldReturn('/uploaded/TestFolder/File/file.jpg');
+        $this->filePath($file, 'uploaded')->shouldReturn('/uploaded/TestFolder/File/file%3Aname.jpg');
     }
 
-    function it_generate_url_with_file_path_prefix_that_should_be_trimed(File $file, Filesystem $filesystem, Local $adapter)
-    {
-        $file->getKey()->shouldBeCalled()->willReturn('TestFolder/File/file.jpg');
-        $file->getFilesystem()->shouldBeCalled()->willReturn($filesystem);
+    function it_generate_url_with_file_path_prefix_that_should_be_trimed(
+        File $file, Filesystem $filesystem, Local $adapter
+    ) {
+        $file->getKey()->willReturn('TestFolder/File/file<>name.jpg');
+        $file->getFilesystem()->willReturn($filesystem);
         $filesystem->getAdapter()->willReturn($adapter);
 
-        $this->fileAsset($file, '/uploaded/')->shouldReturn('/uploaded/TestFolder/File/file.jpg');
-        $this->filePath($file, '/uploaded/')->shouldReturn('/uploaded/TestFolder/File/file.jpg');
+        $this->filePath($file, '/uploaded/')->shouldReturn('/uploaded/TestFolder/File/file%3C%3Ename.jpg');
     }
 
-    function it_generate_url_for_fsi_file_with_external_adapter(File $file, Filesystem $filesystem, Local $adapter)
-    {
-        $file->getKey()->shouldBeCalled()->willReturn('TestFolder/File/file.jpg');
-        $file->getFilesystem()->shouldBeCalled()->willReturn($filesystem);
+    function it_generate_url_for_fsi_file_with_external_adapter(
+        File $file, Filesystem $filesystem, Local $adapter
+    ) {
+        $file->getKey()->willReturn('Test Folder/File/nazwy plików.jpg');
+        $file->getFilesystem()->willReturn($filesystem);
         $filesystem->getAdapter()->willReturn($adapter);
 
-        $file->getContent()->shouldBeCalled()->willReturn('file content');
+        $file->getContent()->willReturn('file content');
 
-        $this->fileAsset($file)->shouldReturn('/TestFolder/File/file.jpg');
-        $this->filePath($file)->shouldReturn('/TestFolder/File/file.jpg');
+        $this->filePath($file)->shouldReturn('/uploaded/Test%20Folder/File/nazwy%20plik%C3%B3w.jpg');
     }
 
     function it_generate_url_with_prefix_from_globals(
         Twig_Environment $environment, File $file, Filesystem $filesystem, Local $adapter
     ) {
-        $environment->getGlobals()->willReturn(array(
-                'fsi_file_prefix' => 'uploaded'
-            ));
-        $this->initRuntime($environment);
+        $environment->getGlobals()->willReturn(array('fsi_file_prefix' => 'uploaded'));
+        $environment->initRuntime();
 
-        $file->getKey()->shouldBeCalled()->willReturn('TestFolder/File/file.jpg');
-        $file->getFilesystem()->shouldBeCalled()->willReturn($filesystem);
+        $file->getKey()->willReturn('TestFolder/File/file%name.jpg');
+        $file->getFilesystem()->willReturn($filesystem);
         $filesystem->getAdapter()->willReturn($adapter);
 
-        $this->fileAsset($file)->shouldReturn('/uploaded/TestFolder/File/file.jpg');
-        $this->filePath($file)->shouldReturn('/uploaded/TestFolder/File/file.jpg');
+        $this->filePath($file)->shouldReturn('/uploaded/TestFolder/File/file%25name.jpg');
     }
 
     function it_generate_url_with_passed_prefix_even_if_there_is_a_prefix_in_globals(
@@ -96,14 +91,14 @@ class FSiFilePathResolverSpec extends ObjectBehavior
         $environment->getGlobals()->willReturn(array(
                 'fsi_file_prefix' => 'uploaded'
             ));
-        $this->initRuntime($environment);
+        $environment->initRuntime();
 
-        $file->getKey()->shouldBeCalled()->willReturn('TestFolder/File/file.jpg');
-        $file->getFilesystem()->shouldBeCalled()->willReturn($filesystem);
+        $file->getKey()->willReturn('TestFolder/File/file1@2.jpg');
+        $file->getFilesystem()->willReturn($filesystem);
         $filesystem->getAdapter()->willReturn($adapter);
 
-        $this->fileAsset($file, 'my_prefix')->shouldReturn('/my_prefix/TestFolder/File/file.jpg');
-        $this->filePath($file, 'my_prefix')->shouldReturn('/my_prefix/TestFolder/File/file.jpg');
+
+        $this->filePath($file, 'my_prefix')->shouldReturn('/my_prefix/TestFolder/File/file1%402.jpg');
     }
 
     /**
@@ -111,7 +106,7 @@ class FSiFilePathResolverSpec extends ObjectBehavior
      */
     function it_generate_fsi_file_basename($file)
     {
-        $file->getName()->shouldBeCalled()->willReturn('TestFolder/File/file.jpg');
+        $file->getName()->willReturn('TestFolder/File/file.jpg');
 
         $this->fileBasename($file)->shouldReturn('file.jpg');
     }

--- a/spec/FSi/Bundle/DoctrineExtensionsBundle/Resolver/FSiFilePathResolverSpec.php
+++ b/spec/FSi/Bundle/DoctrineExtensionsBundle/Resolver/FSiFilePathResolverSpec.php
@@ -14,6 +14,7 @@ use Gaufrette\Adapter\Local;
 use Gaufrette\Adapter\Cache;
 use Gaufrette\Filesystem;
 use PhpSpec\ObjectBehavior;
+use FSi\Bundle\DoctrineExtensionsBundle\Listener\Uploadable\Filesystem as UploadableFilesystem;
 use Twig_Environment;
 
 class FSiFilePathResolverSpec extends ObjectBehavior
@@ -23,7 +24,7 @@ class FSiFilePathResolverSpec extends ObjectBehavior
         $this->beConstructedWith(__DIR__ . '/tmp', 'uploaded');
     }
 
-    function it_generate_url_for_fsi_file_with_local_adapter(File $file, Filesystem $filesystem, Local $adapter)
+    function it_generate_path_for_fsi_file_with_local_adapter(File $file, Filesystem $filesystem, Local $adapter)
     {
         $file->getKey()->willReturn('TestFolder/File/file name.jpg');
         $file->getFilesystem()->willReturn($filesystem);
@@ -32,7 +33,7 @@ class FSiFilePathResolverSpec extends ObjectBehavior
         $this->filePath($file)->shouldReturn('/uploaded/TestFolder/File/file%20name.jpg');
     }
 
-    function it_generate_url_for_fsi_file_with_cache_adapter(File $file, Filesystem $filesystem, Local $adapter)
+    function it_generate_path_for_fsi_file_with_cache_adapter(File $file, Filesystem $filesystem, Local $adapter)
     {
         $file->getKey()->willReturn('/TestFolder/File/file&name.jpg');
         $file->getFilesystem()->willReturn($filesystem);
@@ -41,7 +42,7 @@ class FSiFilePathResolverSpec extends ObjectBehavior
         $this->filePath($file)->shouldReturn('/uploaded/TestFolder/File/file%26name.jpg');
     }
 
-    function it_generate_url_with_file_path_prefix(File $file, Filesystem $filesystem, Cache $adapter)
+    function it_generate_path_with_file_path_prefix(File $file, Filesystem $filesystem, Cache $adapter)
     {
         $file->getKey()->willReturn('/TestFolder/File/file:name.jpg');
         $file->getFilesystem()->willReturn($filesystem);
@@ -50,7 +51,7 @@ class FSiFilePathResolverSpec extends ObjectBehavior
         $this->filePath($file, 'uploaded')->shouldReturn('/uploaded/TestFolder/File/file%3Aname.jpg');
     }
 
-    function it_generate_url_with_file_path_prefix_that_should_be_trimed(
+    function it_generate_path_with_file_path_prefix_that_should_be_trimed(
         File $file, Filesystem $filesystem, Local $adapter
     ) {
         $file->getKey()->willReturn('TestFolder/File/file<>name.jpg');
@@ -60,7 +61,7 @@ class FSiFilePathResolverSpec extends ObjectBehavior
         $this->filePath($file, '/uploaded/')->shouldReturn('/uploaded/TestFolder/File/file%3C%3Ename.jpg');
     }
 
-    function it_generate_url_for_fsi_file_with_external_adapter(
+    function it_generate_path_for_fsi_file_with_external_adapter(
         File $file, Filesystem $filesystem, Local $adapter
     ) {
         $file->getKey()->willReturn('Test Folder/File/nazwy plików.jpg');
@@ -72,7 +73,7 @@ class FSiFilePathResolverSpec extends ObjectBehavior
         $this->filePath($file)->shouldReturn('/uploaded/Test%20Folder/File/nazwy%20plik%C3%B3w.jpg');
     }
 
-    function it_generate_url_with_prefix_from_globals(
+    function it_generate_path_with_prefix_from_globals(
         Twig_Environment $environment, File $file, Filesystem $filesystem, Local $adapter
     ) {
         $environment->getGlobals()->willReturn(array('fsi_file_prefix' => 'uploaded'));
@@ -85,7 +86,7 @@ class FSiFilePathResolverSpec extends ObjectBehavior
         $this->filePath($file)->shouldReturn('/uploaded/TestFolder/File/file%25name.jpg');
     }
 
-    function it_generate_url_with_passed_prefix_even_if_there_is_a_prefix_in_globals(
+    function it_generate_path_with_passed_prefix_even_if_there_is_a_prefix_in_globals(
         Twig_Environment $environment, File $file, Filesystem $filesystem, Local $adapter
     ) {
         $environment->getGlobals()->willReturn(array(
@@ -99,6 +100,16 @@ class FSiFilePathResolverSpec extends ObjectBehavior
 
 
         $this->filePath($file, 'my_prefix')->shouldReturn('/my_prefix/TestFolder/File/file1%402.jpg');
+    }
+
+    function it_generate_url_for_fsi_file_with_base_url_set(
+        File $file, UploadableFilesystem $filesystem, Local $adapter
+    ) {
+        $file->getKey()->willReturn('TestFolder/File/file name.jpg');
+        $file->getFilesystem()->willReturn($filesystem);
+        $filesystem->getBaseUrl()->willReturn("http://domain.com/basepath/");
+
+        $this->fileUrl($file)->shouldReturn('http://domain.com/basepath/TestFolder/File/file%20name.jpg');
     }
 
     /**

--- a/spec/FSi/Bundle/DoctrineExtensionsBundle/Twig/Extension/AssetsSpec.php
+++ b/spec/FSi/Bundle/DoctrineExtensionsBundle/Twig/Extension/AssetsSpec.php
@@ -14,6 +14,7 @@ use FSi\DoctrineExtensions\Uploadable\File;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Bundle\TwigBundle\Extension\AssetsExtension;
+use Symfony\Component\Routing\RequestContext;
 
 class AssetsSpec extends ObjectBehavior
 {
@@ -41,13 +42,14 @@ class AssetsSpec extends ObjectBehavior
         $this->getFunctions()->shouldHaveFunction('fsi_file_asset');
     }
 
-    function it_compute_file_asset_path(File $file, AssetsExtension $assets, FSiFilePathResolver $filePathResolver)
-    {
+    function it_compute_file_asset_path(
+        File $file, AssetsExtension $assets, FSiFilePathResolver $filePathResolver
+    ) {
         $file->getKey()->willReturn('file-name.txt');
-        $filePathResolver->filePath($file, 'uploaded')->willReturn('/uploaded/file-name.txt');
-        $assets->getAssetUrl('/uploaded/file-name.txt')->willReturn('/uploaded/file-name.txt');
+        $filePathResolver->filePath($file, 'uploaded')->willReturn('/uploaded/file%20name.txt');
+        $assets->getAssetUrl('/uploaded/file%20name.txt')->willReturn('/uploaded/file%20name.txt');
 
-        $this->fileAsset($file, 'uploaded')->shouldReturn('/uploaded/file-name.txt');
+        $this->fileAsset($file, 'uploaded')->shouldReturn('/uploaded/file%20name.txt');
     }
 
     function it_have_fsi_file_path_function()


### PR DESCRIPTION
Each part of an URL is encoded by `rawurlencode()` to be W3C valid.
Updated test suites to validate encoded URLs.
Closes #43 