### PR TITLE
Do not validate empty file values

### DIFF
--- a/Validator/Constraints/Symfony3/FileValidator.php
+++ b/Validator/Constraints/Symfony3/FileValidator.php
@@ -42,6 +42,10 @@ class FileValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
+        if (empty($value)) {
+            return;
+        }
+
         if ($value instanceof FSiFile) {
             $tmpFile = sys_get_temp_dir() . '/' . uniqid();
             file_put_contents($tmpFile, $value->getContent());


### PR DESCRIPTION
With Symfony3+ it is possible that an empty array will be submitted as data for the field value, which will lead to an [unexpected type exception](https://github.com/symfony/validator/blob/c6f3a84c1a7f9c1477ab760bd287a87eac494c96/Constraints/FileValidator.php#L116).

Previously the value was correctly casted to NULL, but currently that does not seem to happen (I am investigating why).

EDIT OK found it - if you set the `multiple` property to true on a field value, the empty data is changed to an array. This breaks the validator.